### PR TITLE
make the repo title blue and bold

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -39,9 +39,10 @@ function listResults(repos) {
 		type: 'list',
 		choices: repos.map(function (repo) {
 			var stars = repo.stargazers_count + figures.star;
+			var fullName = repo.full_name.split('/');
 
 			return {
-				name: repo.full_name + ' ' + chalk.dim(stars),
+				name: fullName[0] + '/' + chalk.blue.bold(fullName[1]) + ' ' + chalk.dim(stars),
 				value: repo.html_url
 			};
 		})
@@ -93,9 +94,10 @@ githubSearchRepos(cli.input[0], cli.flags, function (err, data) {
 
 	data.items.forEach(function (repo) {
 		var stars = repo.stargazers_count + figures.star;
+		var fullName = repo.full_name.split('/');
 
 		console.log([
-			repo.full_name + ' ' + chalk.dim(stars),
+			fullName[0] + '/' + chalk.blue.bold(fullName[1]) + ' ' + chalk.dim(stars),
 			repo.description,
 			chalk.dim(repo.html_url),
 			''


### PR DESCRIPTION
I think that makes it a lot easier to read the titles.

![screen shot 2015-04-20 at 19 41 12](https://cloud.githubusercontent.com/assets/170270/7230139/424a089e-e795-11e4-8179-3cdb765b51ee.png)

The highlight is not applied over the blue though, but that kinda looks like an Inquirer.js bug as it should replace the blue with the cyan highlight.
